### PR TITLE
Review & slightly reword tracing-json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +2972,7 @@ dependencies = [
 name = "tracing-json"
 version = "0.1.0"
 dependencies = [
+ "assert-json-diff",
  "hex",
  "serde_json",
  "tracing",

--- a/crates/amaru-ledger/src/rules/transaction/withdrawals.rs
+++ b/crates/amaru-ledger/src/rules/transaction/withdrawals.rs
@@ -68,7 +68,7 @@ mod test {
     use crate::context::assert::{AssertPreparationContext, AssertValidationContext};
     use amaru_kernel::{include_cbor, include_json, json, KeepRaw, MintedTransactionBody};
     use test_case::test_case;
-    use tracing_json::{verify_traces, with_tracing};
+    use tracing_json::assert_trace;
 
     macro_rules! fixture {
         ($hash:literal) => {
@@ -84,22 +84,15 @@ mod test {
     fn valid_withdrawal(
         (tx, expected_traces): (KeepRaw<'_, MintedTransactionBody<'_>>, Vec<json::Value>),
     ) {
-        with_tracing(|collector| {
-            let mut context = AssertValidationContext::from(AssertPreparationContext {
-                utxo: Default::default(),
-            });
+        assert_trace(
+            || {
+                let mut context = AssertValidationContext::from(AssertPreparationContext {
+                    utxo: Default::default(),
+                });
 
-            assert!(super::execute(&mut context, tx.withdrawals.as_deref()).is_ok());
-
-            let actual_traces = match collector.get_traces() {
-                Ok(traces) => traces.clone(),
-                Err(poisoned_traces) => poisoned_traces.into_inner().clone(),
-            };
-
-            match verify_traces(actual_traces, expected_traces) {
-                Ok(_) => {}
-                Err(e) => panic!("{:?}", e),
-            }
-        });
+                assert!(super::execute(&mut context, tx.withdrawals.as_deref()).is_ok());
+            },
+            expected_traces,
+        );
     }
 }

--- a/crates/tracing-json/Cargo.toml
+++ b/crates/tracing-json/Cargo.toml
@@ -17,3 +17,4 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["json"] }
 hex.workspace = true
+assert-json-diff = "2.0.2"

--- a/crates/tracing-json/src/lib.rs
+++ b/crates/tracing-json/src/lib.rs
@@ -81,34 +81,26 @@ impl JsonVisitor {
     }
 }
 
+macro_rules! record_t {
+    ($title:ident, $ty:ty) => {
+        fn $title(&mut self, field: &tracing::field::Field, value: $ty) {
+            self.add_field(field.name(), json::json!(value));
+        }
+    };
+}
+
 impl tracing::field::Visit for JsonVisitor {
-    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
-        self.add_field(field.name(), json::json!(value));
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.add_field(field.name(), json::json!(format!("{:?}", value)))
     }
 
-    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
-        self.add_field(field.name(), json::json!(value));
-    }
-
-    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-        self.add_field(field.name(), json::json!(value));
-    }
-
-    fn record_i128(&mut self, field: &tracing::field::Field, value: i128) {
-        self.add_field(field.name(), json::json!(value));
-    }
-
-    fn record_u128(&mut self, field: &tracing::field::Field, value: u128) {
-        self.add_field(field.name(), json::json!(value));
-    }
-
-    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
-        self.add_field(field.name(), json::json!(value));
-    }
-
-    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        self.add_field(field.name(), json::json!(value));
-    }
+    record_t!(record_f64, f64);
+    record_t!(record_i64, i64);
+    record_t!(record_u64, u64);
+    record_t!(record_i128, i128);
+    record_t!(record_u128, u128);
+    record_t!(record_bool, bool);
+    record_t!(record_str, &str);
 
     fn record_bytes(&mut self, field: &tracing::field::Field, value: &[u8]) {
         self.add_field(field.name(), json::json!(hex::encode(value)));
@@ -120,10 +112,6 @@ impl tracing::field::Visit for JsonVisitor {
         value: &(dyn std::error::Error + 'static),
     ) {
         self.add_field(field.name(), json::json!(format!("{}", value)))
-    }
-
-    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-        self.add_field(field.name(), json::json!(format!("{:?}", value)))
     }
 }
 


### PR DESCRIPTION
- :round_pushpin: **chore: use transparent struct for wrapping locks.**
    Those are really newtypes, so it makes more sense to treat them as such.

- :round_pushpin: **chore: use small macro to reduce boilerplate in defining visitor.**


- :round_pushpin: **chore: rework user-facing API for tracing-json, focusing on assertions.**
    This simplifies a bit the external API and internal management. We
  provide better diffs from comparing JSON traces.

  The assertion itself is done as part of the function API, instead of
  being duplicated on every call-site.

  I also added a small test within the tracing-json library, which
  currently fails since the library ignores events; I'd argue that it
  shouldn't, but that's up to debate for now.